### PR TITLE
Break lifestream views out into their own modules

### DIFF
--- a/src/generator/lifestream/archive.js
+++ b/src/generator/lifestream/archive.js
@@ -1,0 +1,196 @@
+const fs = require("fs").promises;
+const path = require("path");
+const ejs = require("ejs");
+const { DateTime } = require("luxon");
+const paginate = require("paginate-array");
+
+const PAGE_SIZE = 20;
+const INDEX_TEMPLATE = path.resolve(__dirname, "index.html");
+const SIDEBAR_TEMPLATE = path.resolve(__dirname, "archive.html");
+
+const outputs = Object.freeze({
+  root: path.resolve(__dirname, "..", "..", ".."),
+  archive: Object.freeze({
+    dir: path.resolve(__dirname, "..", "..", "lifestream", "archive"),
+    page(year, month, num) {
+      return path.resolve(
+        this.dir,
+        `archive-${year}-${month}-${String(num).padStart(4, "0")}.html`
+      );
+    },
+  }),
+  partials: Object.freeze({
+    dir: path.resolve(__dirname, "..", "..", "lifestream", "partials"),
+    archive: path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "lifestream",
+      "partials",
+      "archive.html"
+    ),
+  }),
+});
+
+const Archive = (year, month, pageNum) =>
+  Object.freeze({
+    templatePath() {
+      return outputs.archive.page(year, month, pageNum);
+    },
+    urlPath() {
+      if (pageNum === 1) {
+        return `lifestream/archive/${year}/${month}/index.html`;
+      }
+      const page = String(pageNum);
+      return `lifestream/archive/${year}/${month}/page/${page}/index.html`;
+    },
+  });
+
+const contextForPage = (year, month, slice) =>
+  Object.freeze({
+    postAbsoluteUrl(item) {
+      return `/lifestream/${item.id}/`;
+    },
+    postDatestamp(item) {
+      return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
+    },
+    postDateDisplay(item) {
+      return DateTime.fromISO(item.publishDate)
+        .setZone("UTC")
+        .toLocaleString(DateTime.DATETIME_FULL);
+    },
+    hasOlder() {
+      return slice.currentPage < slice.totalPages;
+    },
+    older() {
+      const next = slice.currentPage + 1;
+      return `/lifestream/archive/${year}/${month}/page/${next}/`;
+    },
+    hasNewer() {
+      return slice.currentPage > 1;
+    },
+    newer() {
+      const prev = slice.currentPage - 1;
+      if (prev < 2) {
+        return `/lifestream/archive/${year}/${month}/`;
+      }
+      return `/lifestream/archive/${year}/${month}/page/${prev}/`;
+    },
+    posts: slice.data,
+  });
+
+const compileSidebarPartial = async (archive) => {
+  try {
+    const template = await fs.readFile(SIDEBAR_TEMPLATE, "utf8");
+
+    const context = { archive };
+    const rendered = ejs.render(template, context);
+
+    await fs.mkdir(outputs.partials.dir, { recursive: true });
+    await fs.writeFile(outputs.partials.archive, rendered);
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const compileMonthIndexes = async (
+  year,
+  month,
+  db,
+  page = 1,
+  pageSize = PAGE_SIZE
+) => {
+  try {
+    const posts = [...db];
+    posts.sort((a, b) => b.id - a.id); // decending post ID order
+
+    const slice = paginate(posts, page, pageSize);
+    const context = contextForPage(month, year, slice);
+
+    const template = await fs.readFile(INDEX_TEMPLATE, "utf8");
+
+    const rendered = ejs.render(template, context);
+    await fs.mkdir(outputs.archive.dir, { recursive: true });
+    await fs.writeFile(outputs.archive.page(year, month, page), rendered);
+
+    return Promise.resolve(Archive(year, month, page));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const get = (db) => {
+  const posts = [...db];
+  posts.sort(
+    (a, b) =>
+      DateTime.fromISO(b.publishDate).valueOf() -
+      DateTime.fromISO(a.publishDate).valueOf()
+  );
+
+  const aggregates = new Map();
+  for (const post of posts) {
+    const yearKey = DateTime.fromISO(post.publishDate).setZone("UTC").year;
+    const monthKey = DateTime.fromISO(post.publishDate)
+      .setZone("UTC")
+      .startOf("month")
+      .valueOf();
+    if (!aggregates.has(yearKey)) {
+      aggregates.set(yearKey, new Map());
+    }
+    const year = aggregates.get(yearKey);
+    if (!year.has(monthKey)) {
+      year.set(monthKey, []);
+    }
+    year.get(monthKey).push(post);
+  }
+
+  const archive = new Map();
+  for (const [year, months] of aggregates) {
+    const collected = new Map();
+    for (const [month, count] of months) {
+      collected.set(DateTime.fromMillis(month).setZone("UTC"), count);
+    }
+    archive.set(year, collected);
+  }
+  return archive;
+};
+
+const generate = async (archive, webpackPlugins) => {
+  try {
+    await compileSidebarPartial(archive);
+
+    const promises = [];
+
+    // Archive pages
+    for (const [year, months] of archive) {
+      for (const [month, posts] of months) {
+        for (let page = 0; page * PAGE_SIZE < posts.length; page += 1) {
+          const archive = compileMonthIndexes(
+            year,
+            month.toLocaleString({ month: "2-digit" }),
+            posts,
+            page + 1,
+            PAGE_SIZE
+          );
+          promises.push(archive);
+        }
+      }
+    }
+
+    const archives = await Promise.all(promises);
+    for (const archive of archives) {
+      webpackPlugins.push(archive.templatePath(), archive.urlPath());
+    }
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+module.exports = {
+  generate,
+  get,
+};

--- a/src/generator/lifestream/assets.js
+++ b/src/generator/lifestream/assets.js
@@ -1,0 +1,66 @@
+const fs = require("fs").promises;
+const path = require("path");
+
+const outputs = Object.freeze({
+  dir: path.resolve(__dirname, "..", "..", "lifestream", "assets"),
+  destinationPath(asset) {
+    const filename = path.basename(asset);
+    return path.resolve(this.dir, filename);
+  },
+});
+
+const resolve = (source) => {
+  const asset = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "content",
+    "lifestream",
+    "images",
+    path.basename(source)
+  );
+  return asset;
+};
+
+const copy = async (db) => {
+  try {
+    const posts = [...db];
+
+    await fs.mkdir(outputs.dir, { recursive: true });
+
+    const imagePosts = [];
+    for (const post of posts) {
+      if (post.image !== undefined) {
+        imagePosts.push(post);
+      }
+    }
+
+    const promises = imagePosts.map(async (post) => {
+      const source = resolve(post.image);
+      const destination = outputs.destinationPath(post.image);
+      await fs.copyFile(source, destination);
+
+      Promise.resolve(true);
+    });
+    await Promise.all(promises);
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const prepare = (db) => {
+  // Modify the loaded DB to re-point images at their generated locations.
+  for (const post of db) {
+    if (post.image) {
+      post.image = `../assets/${path.basename(post.image)}`;
+    }
+  }
+};
+
+module.exports = {
+  copy,
+  prepare,
+};

--- a/src/generator/lifestream/hashtag.js
+++ b/src/generator/lifestream/hashtag.js
@@ -1,0 +1,169 @@
+const fs = require("fs").promises;
+const path = require("path");
+const ejs = require("ejs");
+const { DateTime } = require("luxon");
+const paginate = require("paginate-array");
+
+const linkify = require("linkifyjs");
+const linkifyHtml = require("linkifyjs/html");
+const linkifyHashtag = require("linkifyjs/plugins/hashtag");
+linkifyHashtag(linkify);
+
+const PAGE_SIZE = 20;
+
+const TEMPLATE = path.resolve(__dirname, "index.html");
+
+const outputs = Object.freeze({
+  dir: path.resolve(__dirname, "..", "..", "lifestream", "hashtag"),
+  page(hashtag, num) {
+    const page = String(num).padStart(4, "0");
+    return path.resolve(this.dir, `hashtag-${hashtag}-${page}.html`);
+  },
+});
+
+const Hashtag = (hashtag, pageNum) =>
+  Object.freeze({
+    templatePath() {
+      return outputs.page(hashtag, pageNum);
+    },
+    urlPath() {
+      if (pageNum === 1) {
+        return `lifestream/hashtag/${hashtag}/index.html`;
+      }
+      const page = String(pageNum);
+      return `lifestream/hashtag/${hashtag}/page/${page}/index.html`;
+    },
+  });
+
+const contextForPage = (hashtag, slice) =>
+  Object.freeze({
+    postAbsoluteUrl(item) {
+      return `/lifestream/${item.id}/`;
+    },
+    postDatestamp(item) {
+      return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
+    },
+    postDateDisplay(item) {
+      return DateTime.fromISO(item.publishDate)
+        .setZone("UTC")
+        .toLocaleString(DateTime.DATETIME_FULL);
+    },
+    hasOlder() {
+      return slice.currentPage < slice.totalPages;
+    },
+    older() {
+      const next = slice.currentPage + 1;
+      return `/lifestream/hashtag/${hashtag}/page/${next}/`;
+    },
+    hasNewer() {
+      return slice.currentPage > 1;
+    },
+    newer() {
+      const prev = slice.currentPage - 1;
+      if (prev < 2) {
+        return `/lifestream/hashtag/${hashtag}/`;
+      }
+      return `/lifestream/hashtag/${hashtag}/page/${prev}/`;
+    },
+    posts: slice.data,
+  });
+
+const compile = async (hashtag, db, page = 1, pageSize = PAGE_SIZE) => {
+  try {
+    const posts = [...db];
+    posts.sort((a, b) => b.id - a.id); // decending post ID order
+
+    const slice = paginate(posts, page, pageSize);
+    const context = contextForPage(hashtag, slice);
+
+    const template = await fs.readFile(TEMPLATE, "utf8");
+
+    const rendered = ejs.render(template, context);
+    await fs.mkdir(outputs.dir, { recursive: true });
+    await fs.writeFile(outputs.page(hashtag, page), rendered);
+
+    return Promise.resolve(Hashtag(hashtag, page));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const generate = async (db, hashtags, webpackPlugins) => {
+  try {
+    const promises = [];
+
+    for (const [hashtag, postIds] of hashtags) {
+      const posts = [];
+      for (const id of postIds) {
+        const post = db.find((post) => post.id === id);
+        if (post === undefined) {
+          return Promise.reject(`missing post: ${id}`);
+        }
+        posts.push(post);
+      }
+      for (let page = 0; page * PAGE_SIZE < posts.length; page += 1) {
+        const index = compile(hashtag, posts, page + 1);
+        promises.push(index);
+      }
+    }
+
+    const indexes = await Promise.all(promises);
+    for (const index of indexes) {
+      webpackPlugins.push(index.templatePath(), index.urlPath());
+    }
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const get = (db) => {
+  const hashtags = new Map();
+  const posts = [...db];
+
+  // Modify the loaded DB to linkify URLs and hashtags.
+  for (const post of posts) {
+    for (const link of linkify.find(post.post)) {
+      if (link.type === "hashtag") {
+        let hashtag = link.value.toLowerCase();
+        // Remove leading `#`.
+        hashtag = hashtag.slice(1);
+
+        if (!hashtags.has(hashtag)) {
+          hashtags.set(hashtag, new Set());
+        }
+        const set = hashtags.get(hashtag);
+        set.add(post.id);
+      }
+    }
+  }
+
+  return hashtags;
+};
+
+const prepare = (db) => {
+  // Modify the loaded DB to linkify URLs and hashtags.
+  for (const post of db) {
+    post.post = linkifyHtml(post.post, {
+      className: "",
+      defaultProtocol: "https",
+      formatHref: {
+        hashtag: (value) => {
+          let hashtag = value;
+          if (hashtag.startsWith("#")) {
+            hashtag = hashtag.slice(1);
+          }
+          return `/lifestream/hashtag/${hashtag}/`;
+        },
+      },
+    });
+  }
+};
+
+module.exports = {
+  compile,
+  generate,
+  get,
+  prepare,
+};

--- a/src/generator/lifestream/index.js
+++ b/src/generator/lifestream/index.js
@@ -2,535 +2,61 @@
 
 const fs = require("fs").promises;
 const path = require("path");
-const ejs = require("ejs");
 const parser = require("js-yaml");
-const { DateTime } = require("luxon");
-const paginate = require("paginate-array");
+
 const pluginBuilder = require("../plugin_payload");
 
-const linkify = require("linkifyjs");
-const linkifyHtml = require("linkifyjs/html");
-const linkifyHashtag = require("linkifyjs/plugins/hashtag");
-linkifyHashtag(linkify);
+const archive = require("./archive");
+const assets = require("./assets");
+const hashtag = require("./hashtag");
+const listing = require("./listing");
+const posts = require("./posts");
 
-const PAGE_SIZE = 20;
+const ROOT = path.resolve(__dirname, "..", "..", "..");
 
-const templates = Object.freeze({
-  archive: path.resolve(__dirname, "archive.html"),
-  asset(source) {
-    const assetRoot = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "..",
-      "content",
-      "lifestream"
-    );
-    return path.resolve(assetRoot, source);
-  },
-  index: path.resolve(__dirname, "index.html"),
-  post: path.resolve(__dirname, "post.html"),
-});
-
-const outputs = Object.freeze({
-  root: path.resolve(__dirname, "..", "..", ".."),
-  archive: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "archive"),
-    page(year, month, num) {
-      return path.resolve(
-        this.dir,
-        `archive-${year}-${month}-${String(num).padStart(4, "0")}.html`
-      );
-    },
-  }),
-  assets: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "assets"),
-    destinationPath(asset) {
-      const filename = path.basename(asset);
-      return path.resolve(this.dir, filename);
-    },
-  }),
-  hashtag: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "hashtag"),
-    page(hashtag, num) {
-      return path.resolve(
-        this.dir,
-        `hashtag-${hashtag}-${String(num).padStart(4, "0")}.html`
-      );
-    },
-  }),
-  index: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "index"),
-    page(num) {
-      return path.resolve(
-        this.dir,
-        `page-${String(num).padStart(4, "0")}.html`
-      );
-    },
-  }),
-  partials: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "partials"),
-    archive: path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "lifestream",
-      "partials",
-      "archive.html"
-    ),
-  }),
-  posts: Object.freeze({
-    dir: path.resolve(__dirname, "..", "..", "lifestream", "posts"),
-    container(id) {
-      return path.resolve(this.dir, id);
-    },
-    page(id) {
-      return path.resolve(this.container(id), "index.html");
-    },
-  }),
-});
-
-const Archive = (year, month, pageNum) =>
-  Object.freeze({
-    templatePath() {
-      return outputs.archive.page(year, month, pageNum);
-    },
-    urlPath() {
-      if (pageNum === 1) {
-        return `lifestream/archive/${year}/${month}/index.html`;
-      }
-      const page = String(pageNum);
-      return `lifestream/archive/${year}/${month}/page/${page}/index.html`;
-    },
-  });
-
-const Hashtag = (hashtag, pageNum) =>
-  Object.freeze({
-    templatePath() {
-      return outputs.hashtag.page(hashtag, pageNum);
-    },
-    urlPath() {
-      if (pageNum === 1) {
-        return `lifestream/hashtag/${hashtag}/index.html`;
-      }
-      const page = String(pageNum);
-      return `lifestream/hashtag/${hashtag}/page/${page}/index.html`;
-    },
-  });
-
-const Index = (pageNum) =>
-  Object.freeze({
-    templatePath() {
-      return outputs.index.page(pageNum);
-    },
-    urlPath() {
-      if (pageNum === 1) {
-        return "lifestream/index.html";
-      }
-      return `lifestream/page/${String(pageNum)}/index.html`;
-    },
-  });
-
-const Post = (id) =>
-  Object.freeze({
-    templatePath() {
-      return outputs.posts.page(id);
-    },
-    urlPath() {
-      return `lifestream/${String(id)}/index.html`;
-    },
-  });
-
-const buildArchive = (db) => {
-  const posts = [...db];
-  posts.sort(
-    (a, b) =>
-      DateTime.fromISO(b.publishDate).valueOf() -
-      DateTime.fromISO(a.publishDate).valueOf()
+const loadDB = async () => {
+  const posts = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "content",
+    "lifestream",
+    "posts.yaml"
   );
-
-  const aggregates = new Map();
-  for (const post of posts) {
-    const yearKey = DateTime.fromISO(post.publishDate).setZone("UTC").year;
-    const monthKey = DateTime.fromISO(post.publishDate)
-      .setZone("UTC")
-      .startOf("month")
-      .valueOf();
-    if (!aggregates.has(yearKey)) {
-      aggregates.set(yearKey, new Map());
-    }
-    const year = aggregates.get(yearKey);
-    if (!year.has(monthKey)) {
-      year.set(monthKey, []);
-    }
-    year.get(monthKey).push(post);
-  }
-
-  const archive = new Map();
-  for (const [year, months] of aggregates) {
-    const collected = new Map();
-    for (const [month, count] of months) {
-      collected.set(DateTime.fromMillis(month).setZone("UTC"), count);
-    }
-    archive.set(year, collected);
-  }
-  return archive;
-};
-
-const compileArchivePartial = async (db) => {
-  try {
-    const archive = buildArchive(db);
-    const template = await fs.readFile(templates.archive, "utf8");
-
-    const context = { archive };
-    const rendered = ejs.render(template, context);
-
-    await fs.mkdir(outputs.partials.dir, { recursive: true });
-    await fs.writeFile(outputs.partials.archive, rendered);
-
-    return Promise.resolve("archive");
-  } catch (err) {
-    return Promise.reject(err);
-  }
-};
-
-const compilePosts = async (db) => {
-  try {
-    const posts = [...db];
-    posts.sort((a, b) => b.id - a.id); // decending post ID order
-
-    const template = await fs.readFile(templates.post, "utf8");
-    await fs.mkdir(outputs.posts.dir, { recursive: true });
-
-    const promises = posts.map(async (post, index, storage) => {
-      const context = {
-        postAbsoluteUrl(item) {
-          return `/lifestream/${item.id}/`;
-        },
-        postDatestamp(item) {
-          return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
-        },
-        postDateDisplay(item) {
-          return DateTime.fromISO(item.publishDate)
-            .setZone("UTC")
-            .toLocaleString(DateTime.DATETIME_FULL);
-        },
-        hasOlder() {
-          return storage[index - 1] !== undefined;
-        },
-        older() {
-          return this.postAbsoluteUrl(storage[index - 1]);
-        },
-        hasNewer() {
-          return storage[index + 1] !== undefined;
-        },
-        newer() {
-          return this.postAbsoluteUrl(storage[index + 1]);
-        },
-        posts: [post],
-      };
-
-      const rendered = ejs.render(template, context);
-
-      await fs.mkdir(outputs.posts.container(post.id), { recursive: true });
-      await fs.writeFile(outputs.posts.page(post.id), rendered);
-      return Post(post.id);
-    });
-
-    return Promise.all(promises);
-  } catch (err) {
-    return Promise.reject(err);
-  }
-};
-
-const compileIndex = async (db, page = 1, pageSize = 20) => {
-  try {
-    const posts = [...db];
-    posts.sort((a, b) => b.id - a.id); // decending post ID order
-
-    const slice = paginate(posts, page, pageSize);
-    const context = {
-      postAbsoluteUrl(item) {
-        return `/lifestream/${item.id}/`;
-      },
-      postDatestamp(item) {
-        return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
-      },
-      postDateDisplay(item) {
-        return DateTime.fromISO(item.publishDate)
-          .setZone("UTC")
-          .toLocaleString(DateTime.DATETIME_FULL);
-      },
-      hasOlder() {
-        return slice.currentPage < slice.totalPages;
-      },
-      older() {
-        const next = slice.currentPage + 1;
-        return `/lifestream/page/${next}/`;
-      },
-      hasNewer() {
-        return slice.currentPage > 1;
-      },
-      newer() {
-        const prev = slice.currentPage - 1;
-        if (prev < 2) {
-          return `/lifestream/`;
-        }
-        return `/lifestream/page/${prev}/`;
-      },
-      posts: slice.data,
-    };
-
-    const template = await fs.readFile(templates.index, "utf8");
-
-    const rendered = ejs.render(template, context);
-    await fs.mkdir(outputs.index.dir, { recursive: true });
-    await fs.writeFile(outputs.index.page(page), rendered);
-
-    return Promise.resolve(Index(page));
-  } catch (err) {
-    return Promise.reject(err);
-  }
-};
-
-const compileArchiveIndex = async (
-  year,
-  month,
-  db,
-  page = 1,
-  pageSize = 20
-) => {
-  try {
-    const posts = [...db];
-    posts.sort((a, b) => b.id - a.id); // decending post ID order
-
-    const slice = paginate(posts, page, pageSize);
-    const context = {
-      postAbsoluteUrl(item) {
-        return `/lifestream/${item.id}/`;
-      },
-      postDatestamp(item) {
-        return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
-      },
-      postDateDisplay(item) {
-        return DateTime.fromISO(item.publishDate)
-          .setZone("UTC")
-          .toLocaleString(DateTime.DATETIME_FULL);
-      },
-      hasOlder() {
-        return slice.currentPage < slice.totalPages;
-      },
-      older() {
-        const next = slice.currentPage + 1;
-        return `/lifestream/archive/${year}/${month}/page/${next}/`;
-      },
-      hasNewer() {
-        return slice.currentPage > 1;
-      },
-      newer() {
-        const prev = slice.currentPage - 1;
-        if (prev < 2) {
-          return `/lifestream/archive/${year}/${month}/`;
-        }
-        return `/lifestream/archive/${year}/${month}/page/${prev}/`;
-      },
-      posts: slice.data,
-    };
-
-    const template = await fs.readFile(templates.index, "utf8");
-
-    const rendered = ejs.render(template, context);
-    await fs.mkdir(outputs.archive.dir, { recursive: true });
-    await fs.writeFile(outputs.archive.page(year, month, page), rendered);
-
-    return Promise.resolve(Archive(year, month, page));
-  } catch (err) {
-    return Promise.reject(err);
-  }
-};
-
-const compileHashtagIndex = async (hashtag, db, page = 1, pageSize = 20) => {
-  try {
-    const posts = [...db];
-    posts.sort((a, b) => b.id - a.id); // decending post ID order
-
-    const slice = paginate(posts, page, pageSize);
-    const context = {
-      postAbsoluteUrl(item) {
-        return `/lifestream/${item.id}/`;
-      },
-      postDatestamp(item) {
-        return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
-      },
-      postDateDisplay(item) {
-        return DateTime.fromISO(item.publishDate)
-          .setZone("UTC")
-          .toLocaleString(DateTime.DATETIME_FULL);
-      },
-      hasOlder() {
-        return slice.currentPage < slice.totalPages;
-      },
-      older() {
-        const next = slice.currentPage + 1;
-        return `/lifestream/hashtag/${hashtag}/page/${next}/`;
-      },
-      hasNewer() {
-        return slice.currentPage > 1;
-      },
-      newer() {
-        const prev = slice.currentPage - 1;
-        if (prev < 2) {
-          return `/lifestream/hashtag/${hashtag}/`;
-        }
-        return `/lifestream/hashtag/${hashtag}/page/${prev}/`;
-      },
-      posts: slice.data,
-    };
-
-    const template = await fs.readFile(templates.index, "utf8");
-
-    const rendered = ejs.render(template, context);
-    await fs.mkdir(outputs.hashtag.dir, { recursive: true });
-    await fs.writeFile(outputs.hashtag.page(hashtag, page), rendered);
-
-    return Promise.resolve(Hashtag(hashtag, page));
-  } catch (err) {
-    return Promise.reject(err);
-  }
-};
-
-const copyAssets = async (db) => {
-  try {
-    const posts = [...db];
-
-    await fs.mkdir(outputs.assets.dir, { recursive: true });
-
-    for (const post of posts) {
-      if (post.image === undefined) {
-        continue;
-      }
-
-      await fs.copyFile(
-        templates.asset(post.image),
-        outputs.assets.destinationPath(post.image)
-      );
-    }
-    return Promise.resolve(true);
-  } catch (err) {
-    return Promise.reject(err);
-  }
+  const rawDb = await fs.readFile(posts, "utf8");
+  const db = parser.safeLoad(rawDb, { schema: parser.FAILSAFE_SCHEMA });
+  return db;
 };
 
 const generator = async () => {
   try {
-    const rawDb = await fs.readFile(
-      path.resolve(
-        __dirname,
-        "..",
-        "..",
-        "..",
-        "content",
-        "lifestream",
-        "posts.yaml"
-      ),
-      "utf8"
-    );
-    const db = parser.safeLoad(rawDb, { schema: parser.FAILSAFE_SCHEMA });
-
+    const db = await loadDB();
     const webpackPlugins = pluginBuilder();
 
-    await copyAssets(db);
+    // Extract bare hashtags before the database is modified to turn them into
+    // links.
+    const hashtags = hashtag.get(db);
 
-    const hashtags = new Map();
+    // These calls mutate the database.
+    posts.prepare(db);
+    hashtag.prepare(db);
+    assets.prepare(db);
 
-    // Modify the loaded DB to linkify URLs and hashtags.
-    for (const post of db) {
-      if (post.image) {
-        post.image = `../assets/${path.basename(post.image)}`;
-      }
-      for (const link of linkify.find(post.post)) {
-        if (link.type === "hashtag") {
-          let hashtag = link.value.toLowerCase();
-          if (hashtag.startsWith("#")) {
-            hashtag = hashtag.slice(1);
-          }
-          if (!hashtags.has(hashtag)) {
-            hashtags.set(hashtag, []);
-          }
-          const set = hashtags.get(hashtag);
-          if (!set.includes(post.id)) {
-            set.push(post.id);
-          }
-          hashtags.set(hashtag, set);
-        }
-      }
-      post.post = linkifyHtml(post.post, {
-        className: "",
-        defaultProtocol: "https",
-        formatHref: {
-          hashtag: (value) => {
-            let hashtag = value;
-            if (hashtag.startsWith("#")) {
-              hashtag = hashtag.slice(1);
-            }
-            return `/lifestream/hashtag/${hashtag}/`;
-          },
-        },
-      });
-    }
-    // Hashtag pages
-    for (const [hashtag, postIds] of new Map([...hashtags.entries()].sort())) {
-      const posts = [];
-      for (const id of postIds) {
-        const post = db.find((post) => post.id === id);
-        if (post === undefined) {
-          throw new Error(`missing post: ${id}`);
-        }
-        posts.push(post);
-      }
-      for (let page = 0; page * PAGE_SIZE < posts.length; page += 1) {
-        const index = await compileHashtagIndex(hashtag, posts, page + 1);
-        webpackPlugins.push(index.templatePath(), index.urlPath());
-      }
-    }
+    await hashtag.generate(db, hashtags, webpackPlugins);
+    await assets.copy(db);
 
-    await compileArchivePartial(db);
+    const postArchive = archive.get(db);
+    await archive.generate(postArchive, webpackPlugins);
 
-    // Archive pages
-    const archive = buildArchive(db);
-    for (const [year, months] of archive) {
-      for (const [month, posts] of months) {
-        for (let page = 0; page * PAGE_SIZE < posts.length; page += 1) {
-          const archive = await compileArchiveIndex(
-            year,
-            month.toLocaleString({ month: "2-digit" }),
-            posts,
-            page + 1,
-            PAGE_SIZE
-          );
-          webpackPlugins.push(archive.templatePath(), archive.urlPath());
-        }
-      }
-    }
+    await listing.generate(db, webpackPlugins);
 
-    // Feed pages
-    for (let page = 0; page * PAGE_SIZE < db.length; page += 1) {
-      const index = await compileIndex(db, page + 1, PAGE_SIZE);
-      webpackPlugins.push(index.templatePath(), index.urlPath());
-    }
+    await posts.generate(db, webpackPlugins);
 
-    // Post pages
-    const posts = await compilePosts(db);
-    for (const post of posts) {
-      webpackPlugins.push(post.templatePath(), post.urlPath());
-    }
-
-    const config = path.resolve(outputs.root, "webpack.config.lifestream.js");
+    const config = path.resolve(ROOT, "webpack.config.lifestream.js");
     await webpackPlugins.writeTo(config);
   } catch (err) {
-    console.error("Error: Unhandled exception");
-    console.error(err);
-    process.exit(1);
+    return Promise.reject(err);
   }
 };
 

--- a/src/generator/lifestream/listing.js
+++ b/src/generator/lifestream/listing.js
@@ -1,0 +1,105 @@
+const fs = require("fs").promises;
+const path = require("path");
+const ejs = require("ejs");
+const { DateTime } = require("luxon");
+const paginate = require("paginate-array");
+
+const PAGE_SIZE = 20;
+const TEMPLATE = path.resolve(__dirname, "index.html");
+
+const outputs = Object.freeze({
+  dir: path.resolve(__dirname, "..", "..", "lifestream", "index"),
+  page(num) {
+    return path.resolve(this.dir, `page-${String(num).padStart(4, "0")}.html`);
+  },
+});
+
+const Index = (pageNum) =>
+  Object.freeze({
+    templatePath() {
+      return outputs.page(pageNum);
+    },
+    urlPath() {
+      if (pageNum === 1) {
+        return "lifestream/index.html";
+      }
+      return `lifestream/page/${String(pageNum)}/index.html`;
+    },
+  });
+
+const contextForPage = (slice) =>
+  Object.freeze({
+    postAbsoluteUrl(item) {
+      return `/lifestream/${item.id}/`;
+    },
+    postDatestamp(item) {
+      return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
+    },
+    postDateDisplay(item) {
+      return DateTime.fromISO(item.publishDate)
+        .setZone("UTC")
+        .toLocaleString(DateTime.DATETIME_FULL);
+    },
+    hasOlder() {
+      return slice.currentPage < slice.totalPages;
+    },
+    older() {
+      const next = slice.currentPage + 1;
+      return `/lifestream/page/${next}/`;
+    },
+    hasNewer() {
+      return slice.currentPage > 1;
+    },
+    newer() {
+      const prev = slice.currentPage - 1;
+      if (prev < 2) {
+        return `/lifestream/`;
+      }
+      return `/lifestream/page/${prev}/`;
+    },
+    posts: slice.data,
+  });
+
+const compile = async (db, page = 1, pageSize = PAGE_SIZE) => {
+  try {
+    const posts = [...db];
+    posts.sort((a, b) => b.id - a.id); // decending post ID order
+
+    const slice = paginate(posts, page, pageSize);
+    const context = contextForPage(slice);
+
+    const template = await fs.readFile(TEMPLATE, "utf8");
+
+    const rendered = ejs.render(template, context);
+    await fs.mkdir(outputs.dir, { recursive: true });
+    await fs.writeFile(outputs.page(page), rendered);
+
+    return Promise.resolve(Index(page));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const generate = async (db, webpackPlugins) => {
+  try {
+    const promises = [];
+    // Feed pages
+    for (let page = 0; page * PAGE_SIZE < db.length; page += 1) {
+      const index = compile(db, page + 1, PAGE_SIZE);
+      promises.push(index);
+    }
+
+    const indexes = await Promise.all(promises);
+    for (const index of indexes) {
+      webpackPlugins.push(index.templatePath(), index.urlPath());
+    }
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+module.exports = {
+  generate,
+};

--- a/src/generator/lifestream/posts.js
+++ b/src/generator/lifestream/posts.js
@@ -1,0 +1,103 @@
+const fs = require("fs").promises;
+const path = require("path");
+const ejs = require("ejs");
+const { DateTime } = require("luxon");
+
+const TEMPLATE = path.resolve(__dirname, "post.html");
+
+const outputs = Object.freeze({
+  dir: path.resolve(__dirname, "..", "..", "lifestream", "posts"),
+  container(id) {
+    return path.resolve(this.dir, id);
+  },
+  page(id) {
+    return path.resolve(this.container(id), "index.html");
+  },
+});
+
+const Post = (id) =>
+  Object.freeze({
+    templatePath() {
+      return outputs.page(id);
+    },
+    urlPath() {
+      return `lifestream/${String(id)}/index.html`;
+    },
+  });
+
+const contextForPage = (db, index) =>
+  Object.freeze({
+    postAbsoluteUrl(item) {
+      return `/lifestream/${item.id}/`;
+    },
+    postDatestamp(item) {
+      return DateTime.fromISO(item.publishDate).setZone("UTC").toISO();
+    },
+    postDateDisplay(item) {
+      return DateTime.fromISO(item.publishDate)
+        .setZone("UTC")
+        .toLocaleString(DateTime.DATETIME_FULL);
+    },
+    hasOlder() {
+      return db[index - 1] !== undefined;
+    },
+    older() {
+      return this.postAbsoluteUrl(db[index - 1]);
+    },
+    hasNewer() {
+      return db[index + 1] !== undefined;
+    },
+    newer() {
+      return this.postAbsoluteUrl(db[index + 1]);
+    },
+    posts: [db[index]],
+  });
+
+const compile = async (db, post, index, template) => {
+  try {
+    const context = contextForPage(db, index);
+
+    const rendered = ejs.render(template, context);
+
+    await fs.mkdir(outputs.container(post.id), { recursive: true });
+    await fs.writeFile(outputs.page(post.id), rendered);
+    return Promise.resolve(Post(post.id));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const generate = async (db, webpackPlugins) => {
+  try {
+    const posts = [...db];
+    posts.sort((a, b) => b.id - a.id); // decending post ID order
+
+    const template = await fs.readFile(TEMPLATE, "utf8");
+    await fs.mkdir(outputs.dir, { recursive: true });
+
+    const promises = posts.map(async (post, index, storage) =>
+      compile(storage, post, index, template)
+    );
+
+    const gen = await Promise.all(promises);
+    for (const post of gen) {
+      webpackPlugins.push(post.templatePath(), post.urlPath());
+    }
+
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+const prepare = (db) => {
+  // Modify the loaded DB to escape HTML special characters.
+  for (const post of db) {
+    post.post = post.post.replace("<", "&lt;").replace(">", "&gt;");
+  }
+};
+
+module.exports = {
+  generate,
+  prepare,
+};

--- a/webpack.config.lifestream.js
+++ b/webpack.config.lifestream.js
@@ -2,296 +2,8 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 
 module.exports = () => [
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-12factor-0001.html",
-    filename: "lifestream/hashtag/12factor/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ack-0001.html",
-    filename: "lifestream/hashtag/ack/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-adtargeted-0001.html",
-    filename: "lifestream/hashtag/adtargeted/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-airdrop-0001.html",
-    filename: "lifestream/hashtag/airdrop/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-allidoiscode-0001.html",
-    filename: "lifestream/hashtag/allidoiscode/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-android-0001.html",
-    filename: "lifestream/hashtag/android/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ansible-0001.html",
-    filename: "lifestream/hashtag/ansible/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-apache-0001.html",
-    filename: "lifestream/hashtag/apache/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-api-0001.html",
-    filename: "lifestream/hashtag/api/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-apple-0001.html",
-    filename: "lifestream/hashtag/apple/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-artichoke-0001.html",
-    filename: "lifestream/hashtag/artichoke/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-artichoke-0002.html",
-    filename: "lifestream/hashtag/artichoke/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-aurora-0001.html",
-    filename: "lifestream/hashtag/aurora/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-automation-0001.html",
-    filename: "lifestream/hashtag/automation/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-awesome-0001.html",
-    filename: "lifestream/hashtag/awesome/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-awful-0001.html",
-    filename: "lifestream/hashtag/awful/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-aws-0001.html",
-    filename: "lifestream/hashtag/aws/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-aws-0002.html",
-    filename: "lifestream/hashtag/aws/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-backfromthedead-0001.html",
-    filename: "lifestream/hashtag/backfromthedead/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-backintheday-0001.html",
-    filename: "lifestream/hashtag/backintheday/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-backup-0001.html",
-    filename: "lifestream/hashtag/backup/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-backups-0001.html",
-    filename: "lifestream/hashtag/backups/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-bash-0001.html",
-    filename: "lifestream/hashtag/bash/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-bliss-0001.html",
-    filename: "lifestream/hashtag/bliss/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-blog-0001.html",
-    filename: "lifestream/hashtag/blog/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-bootstrap-0001.html",
-    filename: "lifestream/hashtag/bootstrap/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-box-0001.html",
-    filename: "lifestream/hashtag/box/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-boxworks-0001.html",
-    filename: "lifestream/hashtag/boxworks/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-browserwars-0001.html",
-    filename: "lifestream/hashtag/browserwars/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-bug-0001.html",
-    filename: "lifestream/hashtag/bug/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-build-0001.html",
-    filename: "lifestream/hashtag/build/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-c-0001.html",
-    filename: "lifestream/hashtag/c/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cdn-0001.html",
-    filename: "lifestream/hashtag/cdn/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-chrome-0001.html",
-    filename: "lifestream/hashtag/chrome/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-chromecast-0001.html",
-    filename: "lifestream/hashtag/chromecast/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ci-0001.html",
-    filename: "lifestream/hashtag/ci/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-citadel-0001.html",
-    filename: "lifestream/hashtag/citadel/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cloud-0001.html",
-    filename: "lifestream/hashtag/cloud/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cloudflare-0001.html",
-    filename: "lifestream/hashtag/cloudflare/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-comebacktothislater-0001.html",
-    filename: "lifestream/hashtag/comebacktothislater/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-communication-0001.html",
-    filename: "lifestream/hashtag/communication/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-compiling-0001.html",
-    filename: "lifestream/hashtag/compiling/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-concurrency-0001.html",
-    filename: "lifestream/hashtag/concurrency/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-conference-0001.html",
-    filename: "lifestream/hashtag/conference/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cost-0001.html",
-    filename: "lifestream/hashtag/cost/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cron-0001.html",
-    filename: "lifestream/hashtag/cron/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-cruft-0001.html",
-    filename: "lifestream/hashtag/cruft/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-css-0001.html",
-    filename: "lifestream/hashtag/css/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-database-0001.html",
-    filename: "lifestream/hashtag/database/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-databases-0001.html",
-    filename: "lifestream/hashtag/databases/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-dbclass-0001.html",
-    filename: "lifestream/hashtag/dbclass/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-debian-0001.html",
-    filename: "lifestream/hashtag/debian/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-debugging-0001.html",
-    filename: "lifestream/hashtag/debugging/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-deployment-0001.html",
-    filename: "lifestream/hashtag/deployment/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-design-0001.html",
-    filename: "lifestream/hashtag/design/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-devops-0001.html",
-    filename: "lifestream/hashtag/devops/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-distractions-0001.html",
-    filename: "lifestream/hashtag/distractions/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-django-0001.html",
-    filename: "lifestream/hashtag/django/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-django-0002.html",
-    filename: "lifestream/hashtag/django/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-django-0003.html",
-    filename: "lifestream/hashtag/django/page/3/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-docker-0001.html",
-    filename: "lifestream/hashtag/docker/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-docs-0001.html",
-    filename: "lifestream/hashtag/docs/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-doingitthehardway-0001.html",
-    filename: "lifestream/hashtag/doingitthehardway/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-dotfiles-0001.html",
-    filename: "lifestream/hashtag/dotfiles/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-downtime-0001.html",
-    filename: "lifestream/hashtag/downtime/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-easyway-0001.html",
-    filename: "lifestream/hashtag/easyway/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ec2-0001.html",
-    filename: "lifestream/hashtag/ec2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-eclipse-0001.html",
-    filename: "lifestream/hashtag/eclipse/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-emacs-0001.html",
-    filename: "lifestream/hashtag/emacs/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-email-0001.html",
-    filename: "lifestream/hashtag/email/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-emoji-0001.html",
-    filename: "lifestream/hashtag/emoji/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-esalazar-0001.html",
-    filename: "lifestream/hashtag/esalazar/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-excited-0001.html",
-    filename: "lifestream/hashtag/excited/index.html",
+    template: "lifestream/hashtag/hashtag-linux-0001.html",
+    filename: "lifestream/hashtag/linux/index.html",
   }),
   new HtmlWebPackPlugin({
     template: "lifestream/hashtag/hashtag-fail-0001.html",
@@ -326,716 +38,64 @@ module.exports = () => [
     filename: "lifestream/hashtag/fail/page/8/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-failfast-0001.html",
-    filename: "lifestream/hashtag/failfast/index.html",
+    template: "lifestream/hashtag/hashtag-django-0001.html",
+    filename: "lifestream/hashtag/django/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-fanboy-0001.html",
-    filename: "lifestream/hashtag/fanboy/index.html",
+    template: "lifestream/hashtag/hashtag-django-0002.html",
+    filename: "lifestream/hashtag/django/page/2/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-fast-0001.html",
-    filename: "lifestream/hashtag/fast/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ff-0001.html",
-    filename: "lifestream/hashtag/ff/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-finally-0001.html",
-    filename: "lifestream/hashtag/finally/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-firefox-0001.html",
-    filename: "lifestream/hashtag/firefox/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-firstworldproblems-0001.html",
-    filename: "lifestream/hashtag/firstworldproblems/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-flake8-0001.html",
-    filename: "lifestream/hashtag/flake8/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-flash-0001.html",
-    filename: "lifestream/hashtag/flash/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-flex-0001.html",
-    filename: "lifestream/hashtag/flex/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-frontend-0001.html",
-    filename: "lifestream/hashtag/frontend/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ftw-0001.html",
-    filename: "lifestream/hashtag/ftw/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-functional-0001.html",
-    filename: "lifestream/hashtag/functional/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-functionalprogramming-0001.html",
-    filename: "lifestream/hashtag/functionalprogramming/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gardenpath-0001.html",
-    filename: "lifestream/hashtag/gardenpath/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gcc-0001.html",
-    filename: "lifestream/hashtag/gcc/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gemsanity-0001.html",
-    filename: "lifestream/hashtag/gemsanity/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-git-0001.html",
-    filename: "lifestream/hashtag/git/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-git-0002.html",
-    filename: "lifestream/hashtag/git/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-github-0001.html",
-    filename: "lifestream/hashtag/github/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-github-0002.html",
-    filename: "lifestream/hashtag/github/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gocloud-0001.html",
-    filename: "lifestream/hashtag/gocloud/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-golang-0001.html",
-    filename: "lifestream/hashtag/golang/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-golfed-0001.html",
-    filename: "lifestream/hashtag/golfed/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gollum-0001.html",
-    filename: "lifestream/hashtag/gollum/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-good-0001.html",
-    filename: "lifestream/hashtag/good/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-gsd-0001.html",
-    filename: "lifestream/hashtag/gsd/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ha-0001.html",
-    filename: "lifestream/hashtag/ha/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hack-0001.html",
-    filename: "lifestream/hashtag/hack/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hackathon-0001.html",
-    filename: "lifestream/hashtag/hackathon/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hackernews-0001.html",
-    filename: "lifestream/hashtag/hackernews/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hammer-0001.html",
-    filename: "lifestream/hashtag/hammer/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hard-0001.html",
-    filename: "lifestream/hashtag/hard/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hashtag-0001.html",
-    filename: "lifestream/hashtag/hashtag/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hashtags-0001.html",
-    filename: "lifestream/hashtag/hashtags/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-history-0001.html",
-    filename: "lifestream/hashtag/history/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-hyperbola-0001.html",
-    filename: "lifestream/hashtag/hyperbola/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-idea-0001.html",
-    filename: "lifestream/hashtag/idea/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ie9-0001.html",
-    filename: "lifestream/hashtag/ie9/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ihateflex-0001.html",
-    filename: "lifestream/hashtag/ihateflex/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-indexes-0001.html",
-    filename: "lifestream/hashtag/indexes/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-indexing-0001.html",
-    filename: "lifestream/hashtag/indexing/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-interpreter-0001.html",
-    filename: "lifestream/hashtag/interpreter/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ios-0001.html",
-    filename: "lifestream/hashtag/ios/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-itsgreattobehere-0001.html",
-    filename: "lifestream/hashtag/itsgreattobehere/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-itunes-0001.html",
-    filename: "lifestream/hashtag/itunes/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-java-0001.html",
-    filename: "lifestream/hashtag/java/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-javascript-0001.html",
-    filename: "lifestream/hashtag/javascript/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-jetty-0001.html",
-    filename: "lifestream/hashtag/jetty/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-js-0001.html",
-    filename: "lifestream/hashtag/js/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-json-0001.html",
-    filename: "lifestream/hashtag/json/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-junit-0001.html",
-    filename: "lifestream/hashtag/junit/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-kernelpanic-0001.html",
-    filename: "lifestream/hashtag/kernelpanic/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-kubernetes-0001.html",
-    filename: "lifestream/hashtag/kubernetes/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lambda-0001.html",
-    filename: "lifestream/hashtag/lambda/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lame-0001.html",
-    filename: "lifestream/hashtag/lame/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-latex-0001.html",
-    filename: "lifestream/hashtag/latex/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lean-0001.html",
-    filename: "lifestream/hashtag/lean/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-learnability-0001.html",
-    filename: "lifestream/hashtag/learnability/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-learnsomethingnew-0001.html",
-    filename: "lifestream/hashtag/learnsomethingnew/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-leet-0001.html",
-    filename: "lifestream/hashtag/leet/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lessonlearned-0001.html",
-    filename: "lifestream/hashtag/lessonlearned/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-letsencrypt-0001.html",
-    filename: "lifestream/hashtag/letsencrypt/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-linode-0001.html",
-    filename: "lifestream/hashtag/linode/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lint-0001.html",
-    filename: "lifestream/hashtag/lint/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-linux-0001.html",
-    filename: "lifestream/hashtag/linux/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-lolz-0001.html",
-    filename: "lifestream/hashtag/lolz/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-macruby-0001.html",
-    filename: "lifestream/hashtag/macruby/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-magic-0001.html",
-    filename: "lifestream/hashtag/magic/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-maintenance-0001.html",
-    filename: "lifestream/hashtag/maintenance/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-make-0001.html",
-    filename: "lifestream/hashtag/make/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-mario-0001.html",
-    filename: "lifestream/hashtag/mario/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-markdown-0001.html",
-    filename: "lifestream/hashtag/markdown/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-marketing-0001.html",
-    filename: "lifestream/hashtag/marketing/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-mashup-0001.html",
-    filename: "lifestream/hashtag/mashup/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-metadata-0001.html",
-    filename: "lifestream/hashtag/metadata/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-metaprogramming-0001.html",
-    filename: "lifestream/hashtag/metaprogramming/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-mobile-0001.html",
-    filename: "lifestream/hashtag/mobile/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-monitoring-0001.html",
-    filename: "lifestream/hashtag/monitoring/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-mruby-0001.html",
-    filename: "lifestream/hashtag/mruby/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-music-0001.html",
-    filename: "lifestream/hashtag/music/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-mysql-0001.html",
-    filename: "lifestream/hashtag/mysql/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-nagios-0001.html",
-    filename: "lifestream/hashtag/nagios/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-nginx-0001.html",
-    filename: "lifestream/hashtag/nginx/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-no-0001.html",
-    filename: "lifestream/hashtag/no/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-node-0001.html",
-    filename: "lifestream/hashtag/node/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-nostalgia-0001.html",
-    filename: "lifestream/hashtag/nostalgia/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-notetoself-0001.html",
-    filename: "lifestream/hashtag/notetoself/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-objc-0001.html",
-    filename: "lifestream/hashtag/objc/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-oncall-0001.html",
-    filename: "lifestream/hashtag/oncall/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ooyala-0001.html",
-    filename: "lifestream/hashtag/ooyala/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ops-0001.html",
-    filename: "lifestream/hashtag/ops/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-outage-0001.html",
-    filename: "lifestream/hashtag/outage/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-outofmemory-0001.html",
-    filename: "lifestream/hashtag/outofmemory/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-overkill-0001.html",
-    filename: "lifestream/hashtag/overkill/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-packer-0001.html",
-    filename: "lifestream/hashtag/packer/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-pandora-0001.html",
-    filename: "lifestream/hashtag/pandora/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-patch-0001.html",
-    filename: "lifestream/hashtag/patch/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-patch-0002.html",
-    filename: "lifestream/hashtag/patch/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-pep8-0001.html",
-    filename: "lifestream/hashtag/pep8/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-performance-0001.html",
-    filename: "lifestream/hashtag/performance/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-php-0001.html",
-    filename: "lifestream/hashtag/php/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-plan-0001.html",
-    filename: "lifestream/hashtag/plan/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-portal-0001.html",
-    filename: "lifestream/hashtag/portal/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-powerhour-0001.html",
-    filename: "lifestream/hashtag/powerhour/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-programmerresolutions-0001.html",
-    filename: "lifestream/hashtag/programmerresolutions/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-provisioning-0001.html",
-    filename: "lifestream/hashtag/provisioning/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-puppet-0001.html",
-    filename: "lifestream/hashtag/puppet/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-py3-0001.html",
-    filename: "lifestream/hashtag/py3/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-python-0001.html",
-    filename: "lifestream/hashtag/python/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-quora-0001.html",
-    filename: "lifestream/hashtag/quora/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-rails-0001.html",
-    filename: "lifestream/hashtag/rails/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-react-0001.html",
-    filename: "lifestream/hashtag/react/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-redis-0001.html",
-    filename: "lifestream/hashtag/redis/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-redundancy-0001.html",
-    filename: "lifestream/hashtag/redundancy/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-regex-0001.html",
-    filename: "lifestream/hashtag/regex/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ripgrep-0001.html",
-    filename: "lifestream/hashtag/ripgrep/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-root-0001.html",
-    filename: "lifestream/hashtag/root/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-rpc-0001.html",
-    filename: "lifestream/hashtag/rpc/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ruby-0001.html",
-    filename: "lifestream/hashtag/ruby/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ruby-0002.html",
-    filename: "lifestream/hashtag/ruby/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-rubygems-0001.html",
-    filename: "lifestream/hashtag/rubygems/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-rust-0001.html",
-    filename: "lifestream/hashtag/rust/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-rust-0002.html",
-    filename: "lifestream/hashtag/rust/page/2/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-safari-0001.html",
-    filename: "lifestream/hashtag/safari/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-scala-0001.html",
-    filename: "lifestream/hashtag/scala/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-scale-0001.html",
-    filename: "lifestream/hashtag/scale/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-security-0001.html",
-    filename: "lifestream/hashtag/security/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-segfault-0001.html",
-    filename: "lifestream/hashtag/segfault/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-serious-0001.html",
-    filename: "lifestream/hashtag/serious/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-server-0001.html",
-    filename: "lifestream/hashtag/server/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-shell-0001.html",
-    filename: "lifestream/hashtag/shell/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-shoes-0001.html",
-    filename: "lifestream/hashtag/shoes/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-smh-0001.html",
-    filename: "lifestream/hashtag/smh/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-socialmedia-0001.html",
-    filename: "lifestream/hashtag/socialmedia/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-solarized-0001.html",
-    filename: "lifestream/hashtag/solarized/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-songkick-0001.html",
-    filename: "lifestream/hashtag/songkick/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-songza-0001.html",
-    filename: "lifestream/hashtag/songza/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-sonymylo-0001.html",
-    filename: "lifestream/hashtag/sonymylo/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-spoiled-0001.html",
-    filename: "lifestream/hashtag/spoiled/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ssh-0001.html",
-    filename: "lifestream/hashtag/ssh/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-staging-0001.html",
-    filename: "lifestream/hashtag/staging/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-supertab-0001.html",
-    filename: "lifestream/hashtag/supertab/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-swag-0001.html",
-    filename: "lifestream/hashtag/swag/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-sweet-0001.html",
-    filename: "lifestream/hashtag/sweet/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-terraform-0001.html",
-    filename: "lifestream/hashtag/terraform/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thesis2012-0001.html",
-    filename: "lifestream/hashtag/thesis2012/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thingsineedtobuy-0001.html",
-    filename: "lifestream/hashtag/thingsineedtobuy/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thingsishouldfix-0001.html",
-    filename: "lifestream/hashtag/thingsishouldfix/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thingsiwant-0001.html",
-    filename: "lifestream/hashtag/thingsiwant/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thingsthataregood-0001.html",
-    filename: "lifestream/hashtag/thingsthataregood/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thingsthatarenew-0001.html",
-    filename: "lifestream/hashtag/thingsthatarenew/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-thisisa-0001.html",
-    filename: "lifestream/hashtag/thisisa/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-throwback-0001.html",
-    filename: "lifestream/hashtag/throwback/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-timeboxed-0001.html",
-    filename: "lifestream/hashtag/timeboxed/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-tls-0001.html",
-    filename: "lifestream/hashtag/tls/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-turntable-0001.html",
-    filename: "lifestream/hashtag/turntable/index.html",
+    template: "lifestream/hashtag/hashtag-django-0003.html",
+    filename: "lifestream/hashtag/django/page/3/index.html",
   }),
   new HtmlWebPackPlugin({
     template: "lifestream/hashtag/hashtag-tv-0001.html",
     filename: "lifestream/hashtag/tv/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-tweets-0001.html",
-    filename: "lifestream/hashtag/tweets/index.html",
+    template: "lifestream/hashtag/hashtag-distractions-0001.html",
+    filename: "lifestream/hashtag/distractions/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-twitter-0001.html",
-    filename: "lifestream/hashtag/twitter/index.html",
+    template: "lifestream/hashtag/hashtag-ihateflex-0001.html",
+    filename: "lifestream/hashtag/ihateflex/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ubuntu-0001.html",
-    filename: "lifestream/hashtag/ubuntu/index.html",
+    template: "lifestream/hashtag/hashtag-music-0001.html",
+    filename: "lifestream/hashtag/music/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-uiclass-0001.html",
-    filename: "lifestream/hashtag/uiclass/index.html",
+    template: "lifestream/hashtag/hashtag-flash-0001.html",
+    filename: "lifestream/hashtag/flash/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-unix-0001.html",
-    filename: "lifestream/hashtag/unix/index.html",
+    template: "lifestream/hashtag/hashtag-good-0001.html",
+    filename: "lifestream/hashtag/good/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-upnp-0001.html",
-    filename: "lifestream/hashtag/upnp/index.html",
+    template: "lifestream/hashtag/hashtag-idea-0001.html",
+    filename: "lifestream/hashtag/idea/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-utf8-0001.html",
-    filename: "lifestream/hashtag/utf8/index.html",
+    template: "lifestream/hashtag/hashtag-thingsiwant-0001.html",
+    filename: "lifestream/hashtag/thingsiwant/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-ux-0001.html",
-    filename: "lifestream/hashtag/ux/index.html",
+    template: "lifestream/hashtag/hashtag-backfromthedead-0001.html",
+    filename: "lifestream/hashtag/backfromthedead/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-vagrant-0001.html",
-    filename: "lifestream/hashtag/vagrant/index.html",
+    template: "lifestream/hashtag/hashtag-firstworldproblems-0001.html",
+    filename: "lifestream/hashtag/firstworldproblems/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-vanity-0001.html",
-    filename: "lifestream/hashtag/vanity/index.html",
+    template: "lifestream/hashtag/hashtag-sweet-0001.html",
+    filename: "lifestream/hashtag/sweet/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-versioncontrol-0001.html",
-    filename: "lifestream/hashtag/versioncontrol/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-vim-0001.html",
-    filename: "lifestream/hashtag/vim/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-vimftw-0001.html",
-    filename: "lifestream/hashtag/vimftw/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-wasm-0001.html",
-    filename: "lifestream/hashtag/wasm/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-webpack-0001.html",
-    filename: "lifestream/hashtag/webpack/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-webscale-0001.html",
-    filename: "lifestream/hashtag/webscale/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-whatarethesewords-0001.html",
-    filename: "lifestream/hashtag/whatarethesewords/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-whatquota-0001.html",
-    filename: "lifestream/hashtag/whatquota/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-wikipedia-0001.html",
-    filename: "lifestream/hashtag/wikipedia/index.html",
-  }),
-  new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-willcu-0001.html",
-    filename: "lifestream/hashtag/willcu/index.html",
+    template: "lifestream/hashtag/hashtag-lame-0001.html",
+    filename: "lifestream/hashtag/lame/index.html",
   }),
   new HtmlWebPackPlugin({
     template: "lifestream/hashtag/hashtag-win-0001.html",
@@ -1070,16 +130,956 @@ module.exports = () => [
     filename: "lifestream/hashtag/win/page/8/index.html",
   }),
   new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-excited-0001.html",
+    filename: "lifestream/hashtag/excited/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-leet-0001.html",
+    filename: "lifestream/hashtag/leet/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-git-0001.html",
+    filename: "lifestream/hashtag/git/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-git-0002.html",
+    filename: "lifestream/hashtag/git/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ruby-0001.html",
+    filename: "lifestream/hashtag/ruby/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ruby-0002.html",
+    filename: "lifestream/hashtag/ruby/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-backup-0001.html",
+    filename: "lifestream/hashtag/backup/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-quora-0001.html",
+    filename: "lifestream/hashtag/quora/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-itsgreattobehere-0001.html",
+    filename: "lifestream/hashtag/itsgreattobehere/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-rails-0001.html",
+    filename: "lifestream/hashtag/rails/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-magic-0001.html",
+    filename: "lifestream/hashtag/magic/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hashtags-0001.html",
+    filename: "lifestream/hashtag/hashtags/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-bug-0001.html",
+    filename: "lifestream/hashtag/bug/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thingsishouldfix-0001.html",
+    filename: "lifestream/hashtag/thingsishouldfix/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-mashup-0001.html",
+    filename: "lifestream/hashtag/mashup/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-vim-0001.html",
+    filename: "lifestream/hashtag/vim/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-backups-0001.html",
+    filename: "lifestream/hashtag/backups/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-comebacktothislater-0001.html",
+    filename: "lifestream/hashtag/comebacktothislater/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-server-0001.html",
+    filename: "lifestream/hashtag/server/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-serious-0001.html",
+    filename: "lifestream/hashtag/serious/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-bash-0001.html",
+    filename: "lifestream/hashtag/bash/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thisisa-0001.html",
+    filename: "lifestream/hashtag/thisisa/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-songkick-0001.html",
+    filename: "lifestream/hashtag/songkick/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-turntable-0001.html",
+    filename: "lifestream/hashtag/turntable/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-root-0001.html",
+    filename: "lifestream/hashtag/root/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ubuntu-0001.html",
+    filename: "lifestream/hashtag/ubuntu/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-supertab-0001.html",
+    filename: "lifestream/hashtag/supertab/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-bliss-0001.html",
+    filename: "lifestream/hashtag/bliss/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-shoes-0001.html",
+    filename: "lifestream/hashtag/shoes/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-patch-0001.html",
+    filename: "lifestream/hashtag/patch/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-patch-0002.html",
+    filename: "lifestream/hashtag/patch/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ooyala-0001.html",
+    filename: "lifestream/hashtag/ooyala/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-apple-0001.html",
+    filename: "lifestream/hashtag/apple/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-android-0001.html",
+    filename: "lifestream/hashtag/android/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-doingitthehardway-0001.html",
+    filename: "lifestream/hashtag/doingitthehardway/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gollum-0001.html",
+    filename: "lifestream/hashtag/gollum/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-mario-0001.html",
+    filename: "lifestream/hashtag/mario/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-portal-0001.html",
+    filename: "lifestream/hashtag/portal/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-plan-0001.html",
+    filename: "lifestream/hashtag/plan/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-sonymylo-0001.html",
+    filename: "lifestream/hashtag/sonymylo/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-whatarethesewords-0001.html",
+    filename: "lifestream/hashtag/whatarethesewords/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-github-0001.html",
+    filename: "lifestream/hashtag/github/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-github-0002.html",
+    filename: "lifestream/hashtag/github/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-tweets-0001.html",
+    filename: "lifestream/hashtag/tweets/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-upnp-0001.html",
+    filename: "lifestream/hashtag/upnp/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-java-0001.html",
+    filename: "lifestream/hashtag/java/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-lambda-0001.html",
+    filename: "lifestream/hashtag/lambda/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-finally-0001.html",
+    filename: "lifestream/hashtag/finally/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gardenpath-0001.html",
+    filename: "lifestream/hashtag/gardenpath/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-compiling-0001.html",
+    filename: "lifestream/hashtag/compiling/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gcc-0001.html",
+    filename: "lifestream/hashtag/gcc/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-timeboxed-0001.html",
+    filename: "lifestream/hashtag/timeboxed/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hammer-0001.html",
+    filename: "lifestream/hashtag/hammer/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-no-0001.html",
+    filename: "lifestream/hashtag/no/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hard-0001.html",
+    filename: "lifestream/hashtag/hard/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-c-0001.html",
+    filename: "lifestream/hashtag/c/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-wikipedia-0001.html",
+    filename: "lifestream/hashtag/wikipedia/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-backintheday-0001.html",
+    filename: "lifestream/hashtag/backintheday/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ftw-0001.html",
+    filename: "lifestream/hashtag/ftw/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-rpc-0001.html",
+    filename: "lifestream/hashtag/rpc/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-overkill-0001.html",
+    filename: "lifestream/hashtag/overkill/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-unix-0001.html",
+    filename: "lifestream/hashtag/unix/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-vanity-0001.html",
+    filename: "lifestream/hashtag/vanity/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gemsanity-0001.html",
+    filename: "lifestream/hashtag/gemsanity/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cron-0001.html",
+    filename: "lifestream/hashtag/cron/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-esalazar-0001.html",
+    filename: "lifestream/hashtag/esalazar/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-willcu-0001.html",
+    filename: "lifestream/hashtag/willcu/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-chrome-0001.html",
+    filename: "lifestream/hashtag/chrome/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hack-0001.html",
+    filename: "lifestream/hashtag/hack/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-php-0001.html",
+    filename: "lifestream/hashtag/php/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-whatquota-0001.html",
+    filename: "lifestream/hashtag/whatquota/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-firefox-0001.html",
+    filename: "lifestream/hashtag/firefox/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ack-0001.html",
+    filename: "lifestream/hashtag/ack/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-objc-0001.html",
+    filename: "lifestream/hashtag/objc/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-macruby-0001.html",
+    filename: "lifestream/hashtag/macruby/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-bootstrap-0001.html",
+    filename: "lifestream/hashtag/bootstrap/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-allidoiscode-0001.html",
+    filename: "lifestream/hashtag/allidoiscode/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-javascript-0001.html",
+    filename: "lifestream/hashtag/javascript/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-awful-0001.html",
+    filename: "lifestream/hashtag/awful/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thesis2012-0001.html",
+    filename: "lifestream/hashtag/thesis2012/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-interpreter-0001.html",
+    filename: "lifestream/hashtag/interpreter/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-blog-0001.html",
+    filename: "lifestream/hashtag/blog/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-twitter-0001.html",
+    filename: "lifestream/hashtag/twitter/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-socialmedia-0001.html",
+    filename: "lifestream/hashtag/socialmedia/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-golfed-0001.html",
+    filename: "lifestream/hashtag/golfed/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-spoiled-0001.html",
+    filename: "lifestream/hashtag/spoiled/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thingsthatarenew-0001.html",
+    filename: "lifestream/hashtag/thingsthatarenew/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hyperbola-0001.html",
+    filename: "lifestream/hashtag/hyperbola/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-swag-0001.html",
+    filename: "lifestream/hashtag/swag/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-programmerresolutions-0001.html",
+    filename: "lifestream/hashtag/programmerresolutions/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thingsthataregood-0001.html",
+    filename: "lifestream/hashtag/thingsthataregood/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-uiclass-0001.html",
+    filename: "lifestream/hashtag/uiclass/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-smh-0001.html",
+    filename: "lifestream/hashtag/smh/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-vimftw-0001.html",
+    filename: "lifestream/hashtag/vimftw/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-learnsomethingnew-0001.html",
+    filename: "lifestream/hashtag/learnsomethingnew/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-junit-0001.html",
+    filename: "lifestream/hashtag/junit/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-dbclass-0001.html",
+    filename: "lifestream/hashtag/dbclass/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-adtargeted-0001.html",
+    filename: "lifestream/hashtag/adtargeted/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-airdrop-0001.html",
+    filename: "lifestream/hashtag/airdrop/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-emacs-0001.html",
+    filename: "lifestream/hashtag/emacs/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-mysql-0001.html",
+    filename: "lifestream/hashtag/mysql/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-utf8-0001.html",
+    filename: "lifestream/hashtag/utf8/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-easyway-0001.html",
+    filename: "lifestream/hashtag/easyway/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ie9-0001.html",
+    filename: "lifestream/hashtag/ie9/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-browserwars-0001.html",
+    filename: "lifestream/hashtag/browserwars/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-lolz-0001.html",
+    filename: "lifestream/hashtag/lolz/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ssh-0001.html",
+    filename: "lifestream/hashtag/ssh/index.html",
+  }),
+  new HtmlWebPackPlugin({
     template: "lifestream/hashtag/hashtag-womp-0001.html",
     filename: "lifestream/hashtag/womp/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-learnability-0001.html",
+    filename: "lifestream/hashtag/learnability/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hackernews-0001.html",
+    filename: "lifestream/hashtag/hackernews/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-fanboy-0001.html",
+    filename: "lifestream/hashtag/fanboy/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-outofmemory-0001.html",
+    filename: "lifestream/hashtag/outofmemory/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-nostalgia-0001.html",
+    filename: "lifestream/hashtag/nostalgia/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-marketing-0001.html",
+    filename: "lifestream/hashtag/marketing/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-lessonlearned-0001.html",
+    filename: "lifestream/hashtag/lessonlearned/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-eclipse-0001.html",
+    filename: "lifestream/hashtag/eclipse/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-thingsineedtobuy-0001.html",
+    filename: "lifestream/hashtag/thingsineedtobuy/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-awesome-0001.html",
+    filename: "lifestream/hashtag/awesome/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-notetoself-0001.html",
+    filename: "lifestream/hashtag/notetoself/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-latex-0001.html",
+    filename: "lifestream/hashtag/latex/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ux-0001.html",
+    filename: "lifestream/hashtag/ux/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-songza-0001.html",
+    filename: "lifestream/hashtag/songza/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-pandora-0001.html",
+    filename: "lifestream/hashtag/pandora/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-versioncontrol-0001.html",
+    filename: "lifestream/hashtag/versioncontrol/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-rubygems-0001.html",
+    filename: "lifestream/hashtag/rubygems/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-functional-0001.html",
+    filename: "lifestream/hashtag/functional/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-solarized-0001.html",
+    filename: "lifestream/hashtag/solarized/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-json-0001.html",
+    filename: "lifestream/hashtag/json/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-api-0001.html",
+    filename: "lifestream/hashtag/api/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-metaprogramming-0001.html",
+    filename: "lifestream/hashtag/metaprogramming/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-kernelpanic-0001.html",
+    filename: "lifestream/hashtag/kernelpanic/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-flex-0001.html",
+    filename: "lifestream/hashtag/flex/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-xcode-0001.html",
+    filename: "lifestream/hashtag/xcode/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-itunes-0001.html",
+    filename: "lifestream/hashtag/itunes/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-box-0001.html",
+    filename: "lifestream/hashtag/box/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ff-0001.html",
+    filename: "lifestream/hashtag/ff/index.html",
   }),
   new HtmlWebPackPlugin({
     template: "lifestream/hashtag/hashtag-wtf-0001.html",
     filename: "lifestream/hashtag/wtf/index.html",
   }),
   new HtmlWebPackPlugin({
-    template: "lifestream/hashtag/hashtag-xcode-0001.html",
-    filename: "lifestream/hashtag/xcode/index.html",
+    template: "lifestream/hashtag/hashtag-indexing-0001.html",
+    filename: "lifestream/hashtag/indexing/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-databases-0001.html",
+    filename: "lifestream/hashtag/databases/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-safari-0001.html",
+    filename: "lifestream/hashtag/safari/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-debugging-0001.html",
+    filename: "lifestream/hashtag/debugging/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-nginx-0001.html",
+    filename: "lifestream/hashtag/nginx/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-apache-0001.html",
+    filename: "lifestream/hashtag/apache/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-performance-0001.html",
+    filename: "lifestream/hashtag/performance/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-scale-0001.html",
+    filename: "lifestream/hashtag/scale/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hackathon-0001.html",
+    filename: "lifestream/hashtag/hackathon/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ios-0001.html",
+    filename: "lifestream/hashtag/ios/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-metadata-0001.html",
+    filename: "lifestream/hashtag/metadata/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-fast-0001.html",
+    filename: "lifestream/hashtag/fast/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-concurrency-0001.html",
+    filename: "lifestream/hashtag/concurrency/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-jetty-0001.html",
+    filename: "lifestream/hashtag/jetty/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-boxworks-0001.html",
+    filename: "lifestream/hashtag/boxworks/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gocloud-0001.html",
+    filename: "lifestream/hashtag/gocloud/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-gsd-0001.html",
+    filename: "lifestream/hashtag/gsd/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-puppet-0001.html",
+    filename: "lifestream/hashtag/puppet/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-devops-0001.html",
+    filename: "lifestream/hashtag/devops/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ops-0001.html",
+    filename: "lifestream/hashtag/ops/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-scala-0001.html",
+    filename: "lifestream/hashtag/scala/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-outage-0001.html",
+    filename: "lifestream/hashtag/outage/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-staging-0001.html",
+    filename: "lifestream/hashtag/staging/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-indexes-0001.html",
+    filename: "lifestream/hashtag/indexes/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-pep8-0001.html",
+    filename: "lifestream/hashtag/pep8/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-flake8-0001.html",
+    filename: "lifestream/hashtag/flake8/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-python-0001.html",
+    filename: "lifestream/hashtag/python/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-mobile-0001.html",
+    filename: "lifestream/hashtag/mobile/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-database-0001.html",
+    filename: "lifestream/hashtag/database/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-lean-0001.html",
+    filename: "lifestream/hashtag/lean/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-failfast-0001.html",
+    filename: "lifestream/hashtag/failfast/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-docker-0001.html",
+    filename: "lifestream/hashtag/docker/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-webscale-0001.html",
+    filename: "lifestream/hashtag/webscale/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-regex-0001.html",
+    filename: "lifestream/hashtag/regex/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-automation-0001.html",
+    filename: "lifestream/hashtag/automation/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-markdown-0001.html",
+    filename: "lifestream/hashtag/markdown/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-rust-0001.html",
+    filename: "lifestream/hashtag/rust/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-rust-0002.html",
+    filename: "lifestream/hashtag/rust/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-golang-0001.html",
+    filename: "lifestream/hashtag/golang/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-nagios-0001.html",
+    filename: "lifestream/hashtag/nagios/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-css-0001.html",
+    filename: "lifestream/hashtag/css/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-hashtag-0001.html",
+    filename: "lifestream/hashtag/hashtag/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-emoji-0001.html",
+    filename: "lifestream/hashtag/emoji/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-dotfiles-0001.html",
+    filename: "lifestream/hashtag/dotfiles/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-12factor-0001.html",
+    filename: "lifestream/hashtag/12factor/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-docs-0001.html",
+    filename: "lifestream/hashtag/docs/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-kubernetes-0001.html",
+    filename: "lifestream/hashtag/kubernetes/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cloud-0001.html",
+    filename: "lifestream/hashtag/cloud/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-oncall-0001.html",
+    filename: "lifestream/hashtag/oncall/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-debian-0001.html",
+    filename: "lifestream/hashtag/debian/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-linode-0001.html",
+    filename: "lifestream/hashtag/linode/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-node-0001.html",
+    filename: "lifestream/hashtag/node/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-py3-0001.html",
+    filename: "lifestream/hashtag/py3/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-js-0001.html",
+    filename: "lifestream/hashtag/js/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-tls-0001.html",
+    filename: "lifestream/hashtag/tls/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-deployment-0001.html",
+    filename: "lifestream/hashtag/deployment/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-throwback-0001.html",
+    filename: "lifestream/hashtag/throwback/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cruft-0001.html",
+    filename: "lifestream/hashtag/cruft/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-citadel-0001.html",
+    filename: "lifestream/hashtag/citadel/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-aws-0001.html",
+    filename: "lifestream/hashtag/aws/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-aws-0002.html",
+    filename: "lifestream/hashtag/aws/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-letsencrypt-0001.html",
+    filename: "lifestream/hashtag/letsencrypt/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cdn-0001.html",
+    filename: "lifestream/hashtag/cdn/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ansible-0001.html",
+    filename: "lifestream/hashtag/ansible/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-vagrant-0001.html",
+    filename: "lifestream/hashtag/vagrant/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-terraform-0001.html",
+    filename: "lifestream/hashtag/terraform/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-security-0001.html",
+    filename: "lifestream/hashtag/security/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-downtime-0001.html",
+    filename: "lifestream/hashtag/downtime/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-monitoring-0001.html",
+    filename: "lifestream/hashtag/monitoring/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-functionalprogramming-0001.html",
+    filename: "lifestream/hashtag/functionalprogramming/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-maintenance-0001.html",
+    filename: "lifestream/hashtag/maintenance/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-webpack-0001.html",
+    filename: "lifestream/hashtag/webpack/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-frontend-0001.html",
+    filename: "lifestream/hashtag/frontend/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-redis-0001.html",
+    filename: "lifestream/hashtag/redis/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-aurora-0001.html",
+    filename: "lifestream/hashtag/aurora/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-history-0001.html",
+    filename: "lifestream/hashtag/history/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-packer-0001.html",
+    filename: "lifestream/hashtag/packer/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cloudflare-0001.html",
+    filename: "lifestream/hashtag/cloudflare/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-redundancy-0001.html",
+    filename: "lifestream/hashtag/redundancy/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-make-0001.html",
+    filename: "lifestream/hashtag/make/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ha-0001.html",
+    filename: "lifestream/hashtag/ha/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-cost-0001.html",
+    filename: "lifestream/hashtag/cost/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-provisioning-0001.html",
+    filename: "lifestream/hashtag/provisioning/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ripgrep-0001.html",
+    filename: "lifestream/hashtag/ripgrep/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-chromecast-0001.html",
+    filename: "lifestream/hashtag/chromecast/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-react-0001.html",
+    filename: "lifestream/hashtag/react/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-powerhour-0001.html",
+    filename: "lifestream/hashtag/powerhour/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-communication-0001.html",
+    filename: "lifestream/hashtag/communication/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-conference-0001.html",
+    filename: "lifestream/hashtag/conference/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-email-0001.html",
+    filename: "lifestream/hashtag/email/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-segfault-0001.html",
+    filename: "lifestream/hashtag/segfault/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ci-0001.html",
+    filename: "lifestream/hashtag/ci/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-ec2-0001.html",
+    filename: "lifestream/hashtag/ec2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-mruby-0001.html",
+    filename: "lifestream/hashtag/mruby/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-design-0001.html",
+    filename: "lifestream/hashtag/design/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-artichoke-0001.html",
+    filename: "lifestream/hashtag/artichoke/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-artichoke-0002.html",
+    filename: "lifestream/hashtag/artichoke/page/2/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-shell-0001.html",
+    filename: "lifestream/hashtag/shell/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-lint-0001.html",
+    filename: "lifestream/hashtag/lint/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-wasm-0001.html",
+    filename: "lifestream/hashtag/wasm/index.html",
+  }),
+  new HtmlWebPackPlugin({
+    template: "lifestream/hashtag/hashtag-build-0001.html",
+    filename: "lifestream/hashtag/build/index.html",
   }),
   new HtmlWebPackPlugin({
     template: "lifestream/archive/archive-2020-03-0001.html",


### PR DESCRIPTION
Split copy assets, index pages, post pages, archive pages, and hashtag
pages each out into their own modules.

Each module exposes (optionally) the following methods:

- `get`: Return a parsed representation of the database as a
  preprocessing step.
- `prepare`: Modify the database, for example to linkify hashtags.
- `generate`: Generate HTML templates and persist to disk.

Most views use an internal `compile` method for incremenatally compiling
output which is invoked in `generate`.

Each module owns their input and output paths. Each module owns their
page size.

`src/generator/lifestream/index.js` is now an integration point that
orchestrates the build.

This commit improves the parallelism of filesystem operations.