### PR TITLE
Improve Google Lighthouse accessibility score

### DIFF
--- a/src/_header.scss
+++ b/src/_header.scss
@@ -25,7 +25,7 @@ body.contact .nav-link.nav-link-contact,
 body.lifestream .nav-link.nav-link-lifestream,
 body.blog .nav-link.nav-link-blog {
   color: $link-color;
-  background-image: linear-gradient(to bottom, #444 0%, darkgray 100%);
+  background-image: linear-gradient(to bottom, #444 0%, #888 100%);
 }
 
 .navbar-toggler-icon {

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -5,7 +5,7 @@ $theme-colors: (
 
 $hyperbola-bg-dark: #222;
 $hyperbola-bg-light: #444;
-$hyperbola-body-color: darkgray;
+$hyperbola-body-color: #f8f9fa;
 
 $body-bg: $hyperbola-bg-dark;
 $body-color: $hyperbola-body-color;

--- a/src/generator/blog/index.html
+++ b/src/generator/blog/index.html
@@ -40,9 +40,9 @@
               <h2 class="card-title">
                 <a href="<%= post.absoluteUrl %>"> <%= post.title %> </a>
               </h2>
-              <h6 class="card-subtitle mb-2 text-muted">
+              <div class="h6 card-subtitle mb-2 hyperbola-text-timestamp">
                 <a href="/contact/">Ryan Lopopolo</a> | <%= post.publishDate %>
-              </h6>
+              </div>
               <div class="card-text"><%= post.summary %></div>
             </div>
           </div>

--- a/src/generator/blog/template.html
+++ b/src/generator/blog/template.html
@@ -49,7 +49,9 @@
               <h2 class="card-title text-center">
                 <a href="<%= post.absoluteUrl %>"> <%= post.title %> </a>
               </h2>
-              <div class="h6 card-subtitle text-center mb-2 text-muted">
+              <div
+                class="h6 card-subtitle text-center mb-2 hyperbola-text-timestamp"
+              >
                 <a href="/contact/">Ryan Lopopolo</a> | <%= post.publishDate %>
               </div>
               <div class="card-text">

--- a/src/generator/lifestream/index.html
+++ b/src/generator/lifestream/index.html
@@ -47,7 +47,10 @@
             <% } %>
             <div class="card-body">
               <small class="card-subtitle">
-                <time datetime="<%= postDatestamp(post) %>">
+                <time
+                  class="hyperbola-text-timestamp"
+                  datetime="<%= postDatestamp(post) %>"
+                >
                   <%= postDateDisplay(post) %>
                 </time>
                 <a href="<%= postAbsoluteUrl(post) %>">permalink</a>

--- a/src/generator/lifestream/post.html
+++ b/src/generator/lifestream/post.html
@@ -47,7 +47,10 @@
             <% } %>
             <div class="card-body">
               <small class="card-subtitle">
-                <time datetime="<%= postDatestamp(post) %>">
+                <time
+                  class="hyperbola-text-timestamp"
+                  datetime="<%= postDatestamp(post) %>"
+                >
                   <%= postDateDisplay(post) %>
                 </time>
                 <a href="<%= postAbsoluteUrl(post) %>">permalink</a>

--- a/src/index.scss
+++ b/src/index.scss
@@ -18,3 +18,7 @@
   max-width: 100%;
   min-width: 0;
 }
+
+.hyperbola-text-timestamp {
+  color: lighten($text-muted, 20%);
+}


### PR DESCRIPTION
Improve the accessibility score of all hyperbo.la views to 100 in Google
Lighthouse.

The accessbility score previously could not be measured because text was
low-contrast.

This PR makes the following changes:

- Use `text-light` text color from bootstrap.
- Tweak navbar active page gradients to give more contrast with
  hyperbola-colored links.
- Lighten the color of timestamps by 20% from text-muted with a custom
  CSS color and class defined in `index.scss`.

This PR also includes a missed change from #27 and changes an h6 to a div in the
blog index listing.