### PR TITLE
Fix navbar rendering on mobile and small screens

### DIFF
--- a/src/_header.scss
+++ b/src/_header.scss
@@ -7,6 +7,17 @@
   padding-top: 48px;
 }
 
+.navbar .collapse.show .nav-item,
+.navbar .collapsing .nav-item {
+  width: 100%;
+}
+
+.navbar .collapse.show .nav-link,
+.navbar .collapsing .nav-link {
+  width: 100%;
+  text-align: center;
+}
+
 .nav-link:hover {
   background: $hyperbola-body-color;
   color: $hyperbola-bg-dark;

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -1,47 +1,43 @@
-<nav class="navbar navbar-expand-lg p-0">
-  <div class="container d-flex flex-row justify-content-between p-0">
-    <a class="navbar-brand p-0" href="/" aria-label="hyperbola">
-      <img
-        class="float-left"
-        title="hyperbola"
-        alt="Hyperbola logo"
-        src="../brand.svg"
-      />
-      <span class="sr-only">hyperbola</span>
-    </a>
-    <button
-      class="navbar-toggler"
-      type="button"
-      data-toggle="collapse"
-      data-target="#navbarSupportedContent"
-      aria-controls="navbarSupportedContent"
-      aria-expanded="false"
-      aria-label="Toggle navigation"
-    >
-      <span class="navbar-toggler-icon"></span>
-    </button>
+<nav class="navbar navbar-expand-md">
+  <a class="navbar-brand p-0" href="/" aria-label="hyperbola">
+    <img
+      class="float-left"
+      title="hyperbola"
+      alt="Hyperbola logo"
+      src="../brand.svg"
+    />
+    <span class="sr-only">hyperbola</span>
+  </a>
+  <button
+    class="navbar-toggler"
+    type="button"
+    data-toggle="collapse"
+    data-target="#navbarSupportedContent"
+    aria-controls="navbarSupportedContent"
+    aria-expanded="false"
+    aria-label="Toggle navigation"
+  >
+    <span class="navbar-toggler-icon"></span>
+  </button>
 
-    <div class="collapse navbar-collapse mt-auto" id="navbarSupportedContent">
-      <ul class="navbar-nav ml-auto">
-        <div
-          class="container d-flex flex-column flex-md-row justify-content-end align-items-stretch text-center"
-        >
-          <li class="nav-item">
-            <a class="nav-link nav-link-frontpage" href="/"> home </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-contact" href="/contact/"> contact </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-lifestream" href="/lifestream/">
-              lifestream
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-blog" href="/w/"> blog </a>
-          </li>
-        </div>
-      </ul>
-    </div>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav ml-auto">
+      <div class="container d-flex flex-column flex-md-row justify-content-end">
+        <li class="nav-item">
+          <a class="nav-link nav-link-frontpage" href="/"> home </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link nav-link-contact" href="/contact/"> contact </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link nav-link-lifestream" href="/lifestream/">
+            lifestream
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link nav-link-blog" href="/w/"> blog </a>
+        </li>
+      </div>
+    </ul>
   </div>
 </nav>


### PR DESCRIPTION
- Remove wrapping containers and flexboxes from nav partial.
- Make navbar collapse at medium breakpoint. This avoids the scrunched
  view shown in the screenshots in #38.
- Add CSS to expand navbar cells when the navbar is collapsed and open
  at full width, with centered text.

Fixes #38.

## Screenshots

<img width="733" alt="Screen Shot 2020-09-22 at 7 58 18 AM" src="https://user-images.githubusercontent.com/860434/93900361-24303380-fcaa-11ea-94ce-8ce9a69f7a2a.png">
<img width="733" alt="Screen Shot 2020-09-22 at 7 58 21 AM" src="https://user-images.githubusercontent.com/860434/93900390-2b574180-fcaa-11ea-9833-d06c15a9ec9a.png">
<img width="965" alt="Screen Shot 2020-09-22 at 8 00 10 AM" src="https://user-images.githubusercontent.com/860434/93900403-30b48c00-fcaa-11ea-8a25-bf941a937588.png">
