### PR TITLE
Remove explicit minify config blocks for HtmlWebpackPlugin

### DIFF
--- a/webpack.config.contact.js
+++ b/webpack.config.contact.js
@@ -4,12 +4,5 @@ module.exports = () => [
   new HtmlWebPackPlugin({
     template: "contact/index.html",
     filename: "contact/index.html",
-    minify: {
-      collapseWhitespace: true,
-      minifyCSS: true,
-      minifyJS: true,
-      removeComments: true,
-      useShortDoctype: true,
-    },
   }),
 ];

--- a/webpack.config.frontpage.js
+++ b/webpack.config.frontpage.js
@@ -4,12 +4,5 @@ module.exports = () => [
   new HtmlWebPackPlugin({
     template: "frontpage/index.html",
     filename: "index.html",
-    minify: {
-      collapseWhitespace: true,
-      minifyCSS: true,
-      minifyJS: true,
-      removeComments: true,
-      useShortDoctype: true,
-    },
   }),
 ];


### PR DESCRIPTION
minify is turned on with acceptable defaults when mode == production.